### PR TITLE
PHP8.1: Fix return types for arrays

### DIFF
--- a/library/Requests/Cookie/Jar.php
+++ b/library/Requests/Cookie/Jar.php
@@ -58,9 +58,9 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * Check if the given item exists
 	 *
 	 * @param string $key Item key
-	 * @return boolean Does the item exist?
+	 * @return bool Does the item exist?
 	 */
-	public function offsetExists($key) {
+	public function offsetExists($key): bool {
 		return isset($this->cookies[$key]);
 	}
 
@@ -86,7 +86,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
-	public function offsetSet($key, $value) {
+	public function offsetSet($key, $value): void {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
 		}
@@ -99,7 +99,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @param string $key
 	 */
-	public function offsetUnset($key) {
+	public function offsetUnset($key): void {
 		unset($this->cookies[$key]);
 	}
 
@@ -108,6 +108,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @return ArrayIterator
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->cookies);
 	}

--- a/library/Requests/Response/Headers.php
+++ b/library/Requests/Response/Headers.php
@@ -23,6 +23,7 @@ class Requests_Response_Headers extends Requests_Utility_CaseInsensitiveDictiona
 	 * @param string $key
 	 * @return string|null Header value
 	 */
+    #[\ReturnTypeWillChange]
 	public function offsetGet($key) {
 		$key = strtolower($key);
 		if (!isset($this->data[$key])) {
@@ -40,7 +41,7 @@ class Requests_Response_Headers extends Requests_Utility_CaseInsensitiveDictiona
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
-	public function offsetSet($key, $value) {
+	public function offsetSet($key, $value): void {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
 		}
@@ -92,6 +93,7 @@ class Requests_Response_Headers extends Requests_Utility_CaseInsensitiveDictiona
 	 * Converts the internal
 	 * @return ArrayIterator
 	 */
+    #[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new Requests_Utility_FilteredIterator($this->data, array($this, 'flatten'));
 	}

--- a/library/Requests/Utility/CaseInsensitiveDictionary.php
+++ b/library/Requests/Utility/CaseInsensitiveDictionary.php
@@ -35,9 +35,9 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * Check if the given item exists
 	 *
 	 * @param string $key Item key
-	 * @return boolean Does the item exist?
+	 * @return bool Does the item exist?
 	 */
-	public function offsetExists($key) {
+	public function offsetExists($key): bool {
 		$key = strtolower($key);
 		return isset($this->data[$key]);
 	}
@@ -48,6 +48,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+    #[\ReturnTypeWillChange]
 	public function offsetGet($key) {
 		$key = strtolower($key);
 		if (!isset($this->data[$key])) {
@@ -65,7 +66,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
-	public function offsetSet($key, $value) {
+	public function offsetSet($key, $value): void {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
 		}
@@ -79,7 +80,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @param string $key
 	 */
-	public function offsetUnset($key) {
+	public function offsetUnset($key): void {
 		unset($this->data[strtolower($key)]);
 	}
 
@@ -88,6 +89,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @return ArrayIterator
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->data);
 	}


### PR DESCRIPTION
<!--
Thank you for creating this pull request!

Provide a general summary of your changes in the Title above.
And please provide enough information in the description below, so that others can review your pull request (PR).
-->

## Pull Request Type

- [ ] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement

## Context
Allows 1.8.1.x to run on PHP 8.1


## Detailed Description





## Quality assurance

- [ ] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
