### PR TITLE
PHP8.1: Fix NULL param in http_build_query method

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -342,7 +342,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$data = '';
 			}
 			elseif (!is_string($data)) {
-				$data = http_build_query($data, null, '&');
+				$data = http_build_query($data, '', '&');
 			}
 		}
 
@@ -527,7 +527,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$query = $url_parts['query'];
 			}
 
-			$query .= '&' . http_build_query($data, null, '&');
+			$query .= '&' . http_build_query($data, '', '&');
 			$query  = trim($query, '&');
 
 			if (empty($url_parts['query'])) {


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement

## Context

In PHP8 it's deprecated to give a NULL as second param to the `http_build_query` method

## Detailed Description
## Quality assurance

- [ ] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [ ] My code follows the style guidelines of this project.

## Documentation

For new features:

- [ ] I have added a code example showing how to use this feature to the [examples](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [ ] I have added documentation about this feature to the [docs](https://github.com/WordPress/Requests/tree/develop/docs) directory.
If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [README.md](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.